### PR TITLE
fix: :bug: Leftover env requirements from development

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emilohlund-git/metaroute",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "A simple framework for building APIs in TypeScript, with a focus on simplicity and no dependencies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/core/common/import-handler.core.ts
+++ b/src/core/common/import-handler.core.ts
@@ -22,23 +22,18 @@ export class ImportHandler implements Initializable {
 
   protected handleImports = async () => {
     this.logger.debug(`Current working directory: ${process.cwd()}`);
-    const srcDirectory = path.join(
-      process.cwd(),
-      this.configService.get("SRC_DIRECTORY")
-    );
+    const srcDirectory = path.join(process.cwd(), "src");
 
-    const fileTypes = this.configService.get("IMPORT_TYPES").split(",");
+    const fileType = ".ts";
 
-    for (const fileType of fileTypes) {
-      try {
-        this.logger.debug(
-          `Importing ${fileType} files. Directory: ${srcDirectory}.`
-        );
-        await this.importFiles(srcDirectory, fileType);
-      } catch (error: any) {
-        this.logger.error(`Error importing ${fileType} files`);
-        throw new Error(error.message);
-      }
+    try {
+      this.logger.debug(
+        `Importing ${fileType} files. Directory: ${srcDirectory}.`
+      );
+      await this.importFiles(srcDirectory, fileType);
+    } catch (error: any) {
+      this.logger.error(`Error importing ${fileType} files`);
+      throw new Error(error.message);
     }
   };
 


### PR DESCRIPTION
User of framework should not have to specify which src directory the framework is running from, as well as which filetypes to import