### PR TITLE
refactor(HttpRouter): :recycle: Change name on the HttpRouter

### DIFF
--- a/src/core/api/server/routing/controller-handler.core.ts
+++ b/src/core/api/server/routing/controller-handler.core.ts
@@ -24,8 +24,8 @@ import { CacheOptions } from "../../../cache/interfaces/cache-options.interface"
 import { createCacheMiddleware } from "../../../cache/functions/create-cache-middleware";
 
 @Configurator
-export class HttpRouter<T extends Function> extends Router<T> {
-  private readonly logger = new ConsoleLogger(HttpRouter.name);
+export class ControllerHandler<T extends Function> extends Router<T> {
+  private readonly logger = new ConsoleLogger(ControllerHandler.name);
 
   constructor() {
     super();

--- a/src/core/api/server/routing/index.ts
+++ b/src/core/api/server/routing/index.ts
@@ -1,5 +1,5 @@
 export * from "./basic-http.router.core";
 export * from "./event.router";
-export * from "./http.router";
+export * from "./controller-handler.core";
 export * from "./route-registry.core";
 export * from "./router.abstract";

--- a/src/core/common/server-configurator.core.ts
+++ b/src/core/common/server-configurator.core.ts
@@ -6,7 +6,7 @@ import {
 import { Configurator } from "./decorators/configurator.decorator";
 import { MetaRoute } from "./meta-route.container";
 import { EventRouter } from "../api/server/routing/event.router";
-import { HttpRouter } from "../api/server/routing/http.router";
+import { ControllerHandler } from "../api/server/routing/controller-handler.core";
 import { Initializable } from "./interfaces/initializable.interface";
 import { ConsoleLogger } from "./services/console-logger.service";
 import { Server as SocketServer } from "socket.io";
@@ -26,7 +26,7 @@ export class ServerConfigurator implements Initializable {
 
   constructor(
     private readonly configService: ConfigService,
-    private readonly httpRouter: HttpRouter<any>,
+    private readonly httpRouter: ControllerHandler<any>,
     private readonly eventRouter: EventRouter<any>,
     private readonly server: MetaRouteServer
   ) {}

--- a/tests/core/api/routing/http.router.test.ts
+++ b/tests/core/api/routing/http.router.test.ts
@@ -12,7 +12,7 @@ import { MetaRouteRequest } from "@core/api/server/interfaces/meta-route.request
 import { MetaRouteResponse } from "@core/api/server/interfaces/meta-route.response";
 import { MiddlewareHandler } from "@core/api/server/middleware-handler.core";
 import { MetaRouteRouter } from "@core/api/server/routing/basic-http.router.core";
-import { HttpRouter } from "@core/api/server/routing/http.router";
+import { ControllerHandler } from "@core/api/server/routing/controller-handler.core";
 import { RouteRegistry } from "@core/api/server/routing/route-registry.core";
 import "reflect-metadata";
 
@@ -49,14 +49,14 @@ class MockController extends Function {
 describe("HttpRouter", () => {
   let app: MetaRouteServer;
   let controller: MockController;
-  let router: HttpRouter<MockController>;
+  let router: ControllerHandler<MockController>;
   let basicRouter: MetaRouteRouter;
   let registry: RouteRegistry;
   let middlewareHandler: MiddlewareHandler;
 
   beforeEach(() => {
     controller = new MockController();
-    router = new HttpRouter();
+    router = new ControllerHandler();
     registry = new RouteRegistry();
     middlewareHandler = new MiddlewareHandler();
     basicRouter = new MetaRouteRouter(registry, middlewareHandler);

--- a/tests/core/common/server-configurator.core.test.ts
+++ b/tests/core/common/server-configurator.core.test.ts
@@ -1,7 +1,7 @@
 import { MetaRouteServer } from "@core/api/server/basic-http-server.core";
 import { MetaRouteRouter } from "@core/api/server/routing/basic-http.router.core";
 import { EventRouter } from "@core/api/server/routing/event.router";
-import { HttpRouter } from "@core/api/server/routing/http.router";
+import { ControllerHandler } from "@core/api/server/routing/controller-handler.core";
 import { AppConfiguration } from "@core/common/interfaces/app-configuration.interface";
 import { ServerConfigurator } from "@core/common/server-configurator.core";
 import { ConfigService } from "@core/common/services/config.service";
@@ -11,7 +11,7 @@ import { mock } from "ts-mockito";
 describe("ServerConfigurator", () => {
   let serverConfigurator: ServerConfigurator;
   let configService: ConfigService;
-  let httpRouter: HttpRouter<any>;
+  let httpRouter: ControllerHandler<any>;
   let eventRouter: EventRouter<any>;
   let server: MetaRouteServer;
   let appConfiguration: AppConfiguration;
@@ -21,7 +21,7 @@ describe("ServerConfigurator", () => {
   beforeEach(() => {
     environmentStore = mock(EnvironmentStore);
     configService = mock(ConfigService);
-    httpRouter = mock(HttpRouter);
+    httpRouter = mock(ControllerHandler);
     eventRouter = mock(EventRouter);
     metaRouteRouter = mock(MetaRouteRouter);
     server = new MetaRouteServer(metaRouteRouter);


### PR DESCRIPTION
Name did not match responsibilities of the class. Changed the name to better match this.